### PR TITLE
fix gains for no camera Igor config

### DIFF
--- a/kits/igor/igor2DemoIntegrated.m
+++ b/kits/igor/igor2DemoIntegrated.m
@@ -97,7 +97,7 @@ if(cam_module == 1)
         gains = HebiUtils.loadGains([localDir '/igorGains.xml']);
     end
 else
-    gains = HebiUtils.loadGains([localDir '/igorGainsNoCamera.xml']); 
+    gains = HebiUtils.loadGains([localDir '/igorGains_noCamera.xml']); 
 end
 
 while true

--- a/kits/igor/igorGains_noCamera.xml
+++ b/kits/igor/igorGains_noCamera.xml
@@ -3,12 +3,12 @@
    <control_strategy>3 3 4 4 4 4 4 4 4 3 4 4 4 3</control_strategy>
    <position>
       <kp>0 0 10 50 10 50 15 20 10 1 15 20 10 1</kp>
-      <ki>0 0 10 10 10 10 0 0 0 0 0 0 0 0 /ki>
+      <ki>0 0 10 10 10 10 0 0 0 0 0 0 0 0</ki>
       <kd>0 0 0 0 0 0 0 0 0 0 0 0 0 0</kd>
       <feed_forward>0 0 0 0 0 0 0 0 0 0 0 0 0 0</feed_forward>
       <dead_zone>0 0 0 0 0 0 0 0 0 0 0 0 0 0</dead_zone>
       <i_clamp>0 0 5 2 5 2 0 0 0 0.2 0 0 0 0.2</i_clamp>
-      <punch>0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</punch>
+      <punch>0 0 0 0 0 0 0 0 0 0 0 0 0 0</punch>
       <min_target>-inf -inf -inf -inf -inf -inf -inf -inf -inf -inf -inf -inf -inf -inf</min_target>
       <max_target>inf inf inf inf inf inf inf inf inf inf inf inf inf inf</max_target>
       <target_lowpass>1 1 1 1 1 1 1 1 1 1 1 1 1 1</target_lowpass>
@@ -39,7 +39,7 @@
       <kd>0 0 0.001 0.001 0.001 0.001 0.001 0.001 0.001 0.001 0.001 0.001 0.001 0.001</kd>
       <feed_forward>1 1 1 1 1 1 1 1 1 1 1 1 1 1</feed_forward>
       <dead_zone>0 0 0 0 0 0 0 0 0 0 0 0 0 0</dead_zone>
-      <i_clamp>0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</i_clamp>
+      <i_clamp>0 0 0 0 0 0 0 0 0 0 0 0 0 0</i_clamp>
       <punch>0 0 -0 0.01 -0 0.01 -0 -0 -0 -0 -0 -0 -0 -0</punch>
       <min_target>-10 -10 -20 -20 -20 -20 -20 -20 -10 -10 -20 -20 -10 -10</min_target>
       <max_target>10 10 20 20 20 20 20 20 10 10 20 20 10 10</max_target>


### PR DESCRIPTION
This fixes some typos in the gains XML for the Igor II demo, in the no camera configuration. The actual MATLAB script which runs Igor also refers to the wrong XML file for the no camera config