### PR TITLE
Change path in IK example

### DIFF
--- a/basic/x-series_actuator/ex6c_kinematics_inv_kinematics.m
+++ b/basic/x-series_actuator/ex6c_kinematics_inv_kinematics.m
@@ -19,7 +19,7 @@ frameDisp = FrameDisplay();
 % Inverse kinematics is where you specify a desired target pose for the 
 % end-effector and calculate the joint angles that give you that pose.  
 startXYZ = [ 0.5; -0.2; 0.1 ];  % [m]
-endXYZ = [ -0.5; -0.2; 0.1 ];   % [m]
+endXYZ = [ 0.5; 0.2; 0.1 ];   % [m]
 
 % Because the API uses local optimization to calculate IK, you need to give 
 % an initial guess for the joint angles.  The guess should be something


### PR DESCRIPTION
On the basic IK example, it traces a straight line from [0.5, -0.2, 0] to [-0.5, -0.2, 0].  This works OK on the 3 dof arm, but points that are passed through in the vicinity of [0.2, -0.2, 0] tend to be a little collision prone with a 6 DOF arm, given the wrist and the gas spring.  I found a trajectory of [0.5, -0.2, 0] to [0.5, 0.2, 0] to work better here, and I think it would work well on the 3 DOF arm as well.  It also seems to center better in the default workspace (so an elbow up configuration with base angle "0" is in the middle).

Thoughts?