### PR TITLE
change plane of box in IK example

### DIFF
--- a/basic/x-series_actuator/ex7b_robot_6_dof_arm.m
+++ b/basic/x-series_actuator/ex7b_robot_6_dof_arm.m
@@ -32,9 +32,9 @@ cmd = CommandStruct();
 group.startLog('dir','logs');
 
 % Four Corners of a Box
-xyzTargets = [ 0.20  0.50  0.50  0.20;    % x [m]
+xyzTargets = [ 0.40  0.40  0.40  0.40;    % x [m]
                0.20  0.20 -0.20 -0.20;    % y [m]
-               0.20  0.20  0.20  0.20 ];  % z [m]
+               0.10  0.50  0.50  0.10 ];  % z [m]
 
 % Rotation matrix that makes the end-effector point straight forward
 rotMatTarget = R_y(pi/2);   % [3x3 SO3 Matrix]


### PR DESCRIPTION
Again, for 6DOF arm, the area around the ray [0.2, 0.2, z > 0] seems to be a bad area of the workspace.