### PR TITLE
Update legacy examples

### DIFF
--- a/advanced/youtube/io_board/demo2_live_commands.m
+++ b/advanced/youtube/io_board/demo2_live_commands.m
@@ -26,6 +26,6 @@ while true
     cmd.(led_b) = fbk.(potentiometer) > potentiometerVoltageThreshold;
 
     % Send commands
-    ioBoard.set(cmd);
+    ioBoard.send(cmd);
 
 end

--- a/advanced/youtube/io_board/demo3_actuator.m
+++ b/advanced/youtube/io_board/demo3_actuator.m
@@ -16,6 +16,6 @@ while true
     % Map analog sensor feedback to position command
     fbk = ioBoard.getNextFeedback(tmpFbk);
     cmd.position = fbk.(potentiometer) * positionCmdScale;
-    actuator.set(cmd);
+    actuator.send(cmd);
 
 end

--- a/advanced/youtube/io_board/demo4_logging.m
+++ b/advanced/youtube/io_board/demo4_logging.m
@@ -17,7 +17,7 @@ blinkPeriod = 0.1;
 
 while toc(t) < 5
     cmd.(led_r) = ~cmd.(led_r);
-    ioBoard.set(cmd);
+    ioBoard.send(cmd);
     pause(blinkPeriod); 
 end
 

--- a/basic/mobile_io/ex1b_newGroup_single_module.m
+++ b/basic/mobile_io/ex1b_newGroup_single_module.m
@@ -21,7 +21,7 @@ HebiLookup.initialize();
 % Use Scope to change select a module and change the name and family to
 % match the names below.  Following examples will use the same names.
 familyName = 'HEBI';
-moduleNames = 'Virtual IO';
+moduleNames = 'Mobile IO';
 
 group = HebiLookup.newGroupFromNames( familyName, moduleNames )
 

--- a/basic/mobile_io/ex2a_feedback.m
+++ b/basic/mobile_io/ex2a_feedback.m
@@ -13,7 +13,7 @@ HebiLookup.initialize();
 % Use Scope to change select a module and change the name and family to
 % match the names below.  Following examples will use the same names.
 familyName = 'HEBI';
-moduleNames = 'Virtual IO';
+moduleNames = 'Mobile IO';
 group = HebiLookup.newGroupFromNames( familyName, moduleNames );
 
 %% Visualize Gyro Feedback

--- a/basic/mobile_io/ex2b_feedback_io_w_logging.m
+++ b/basic/mobile_io/ex2b_feedback_io_w_logging.m
@@ -14,7 +14,7 @@ HebiLookup.initialize();
 % Use Scope to change select a module and change the name and family to
 % match the names below.  Following examples will use the same names.
 familyName = 'HEBI';
-moduleNames = 'Virtual IO';
+moduleNames = 'Mobile IO';
 group = HebiLookup.newGroupFromNames( familyName, moduleNames );
 
 %% Visualize Slider Input

--- a/basic/mobile_io/ex2c_feedback_orientation.m
+++ b/basic/mobile_io/ex2c_feedback_orientation.m
@@ -13,7 +13,7 @@ HebiLookup.initialize();
 % Use Scope to change select a module and change the name and family to
 % match the names below.  Following examples will use the same names.
 familyName = 'HEBI';
-moduleNames = 'Virtual IO';
+moduleNames = 'Mobile IO';
 group = HebiLookup.newGroupFromNames( familyName, moduleNames );
 
 %% Visualize Device Orientation

--- a/basic/mobile_io/ex2d_feedback_full_pose.m
+++ b/basic/mobile_io/ex2d_feedback_full_pose.m
@@ -12,8 +12,8 @@ HebiLookup.initialize();
 
 % Use Scope to change select a module and change the name and family to
 % match the names below.  Following examples will use the same names.
-familyName = 'Android';
-moduleNames = 'Phone';
+familyName = 'HEBI';
+moduleNames = 'Mobile IO';
 group = HebiLookup.newGroupFromNames( familyName, moduleNames );
 
 group.startLog('dir','logs');

--- a/basic/mobile_io/ex2e_feedback_pose_w_magnetometer.m
+++ b/basic/mobile_io/ex2e_feedback_pose_w_magnetometer.m
@@ -11,7 +11,7 @@
 clear *;
 close all;
 HebiLookup.initialize(); 
-group = HebiLookup.newGroupFromNames( 'HEBI', 'Virtual IO' );
+group = HebiLookup.newGroupFromNames( 'HEBI', 'Mobile IO' );
 
 %% Gather data w/ visualization
 disp('  Visualizing 6-DoF pose estimate from the mobile device.');

--- a/basic/mobile_io/ex3a_feedback_io_and_mobile.m
+++ b/basic/mobile_io/ex3a_feedback_io_and_mobile.m
@@ -10,7 +10,7 @@
 clear *;
 close all;
 HebiLookup.initialize();
-group = HebiLookup.newGroupFromNames( 'HEBI', 'Virtual IO' );
+group = HebiLookup.newGroupFromNames( 'HEBI', 'Mobile IO' );
 
 %% Gather data w/ visualization
 disp('  Drag the sliders on the app screen and move the device...');

--- a/kits/rosie/rosieDemo.m
+++ b/kits/rosie/rosieDemo.m
@@ -106,7 +106,7 @@ function rosieDemo( mobileBaseType )
     % Setup Mobile I/O Group %
     %%%%%%%%%%%%%%%%%%%%%%%%%%
     phoneFamily = 'HEBI';
-    phoneName = 'Virtual IO';
+    phoneName = 'Mobile IO';
 
     while true        
         try


### PR DESCRIPTION
* Changed all occurences of `Virtual IO` to the new `Mobile IO` default name for Android/iOS
* Updated legacy examples that were still using `group.set()` from a long time ago
