### PR TITLE
Fix Typo in setupArm.n for 4-DoF Configs

### DIFF
--- a/kits/arms/setupArm.m
+++ b/kits/arms/setupArm.m
@@ -193,7 +193,7 @@ switch kit
             'J1_base'
             'J2_shoulder'
             'J3_elbow'
-            'J4_wrist1' });
+            'J4_wrist' });
         
         % Kinematic Model
         kin = HebiKinematics([localDir '/hrdf/A-2085-04']);
@@ -216,7 +216,7 @@ switch kit
             'J1_base'
             'J2_shoulder'
             'J3_elbow'
-            'J4_wrist1' });
+            'J4_wrist' });
         
         % Kinematic Model
         kin = HebiKinematics([localDir '/hrdf/A-2084-01']);
@@ -368,7 +368,7 @@ switch kit
             'J1_base'
             'J2_shoulder'
             'J3_elbow'
-            'J4_wrist1' });
+            'J4_wrist' });
         
         % Kinematic Model
         kin = HebiKinematics([localDir '/hrdf/A-2240-04']);
@@ -391,7 +391,7 @@ switch kit
             'J1_base'
             'J2_shoulder'
             'J3_elbow'
-            'J4_wrist1' });
+            'J4_wrist' });
         
         % Kinematic Model
         kin = HebiKinematics([localDir '/hrdf/A-2302-01']);


### PR DESCRIPTION
Fixed 4-DoF arms typo that had only 1 wrist to properly call it 'J4_wrist' instead of 'J4_wrist1'.