### PR TITLE
naming convention quick fix for gripper in setupArm

### DIFF
--- a/kits/arms/setupArm.m
+++ b/kits/arms/setupArm.m
@@ -423,7 +423,7 @@ HebiUtils.sendWithRetry(arm.group, 'gains', params.gains);
 gripper = [];
 if params.hasGripper
     
-    gripperGroup = HebiLookup.newGroupFromNames( family, 'Spool' );
+    gripperGroup = HebiLookup.newGroupFromNames( family, 'gripperSpool' );
     HebiUtils.sendWithRetry(gripperGroup, 'gains', params.gripperGains);
     
     gripper = HebiGripper(gripperGroup);


### PR DESCRIPTION
changed from "Spool" to "gripperSpool" as per naming convention