### PR TITLE
Fix typo with `nargin`

### DIFF
--- a/kits/arms/setupArm.m
+++ b/kits/arms/setupArm.m
@@ -63,7 +63,7 @@ function [ arm, params, gripper ] = setupArm( kit, family, hasGasSpring )
 localDir = fileparts(mfilename('fullpath'));
 params.localDir = localDir;
 
-if nargin < 4 || isempty(hasGasSpring)
+if nargin < 3 || isempty(hasGasSpring)
    hasGasSpring = false;
 end
 


### PR DESCRIPTION
Number of arguments to check should be 3, not 4.  This is causing `hasGasSpring` to always be false.