### PR TITLE
Implemented plugins as a struct instead of cell

### DIFF
--- a/include/hebi/HebiArm.m
+++ b/include/hebi/HebiArm.m
@@ -35,7 +35,7 @@ classdef HebiArm < handle
     
     properties(Access = public)
         state struct = [];
-        plugins cell = {};
+        plugins struct = struct();
     end
     
     properties(Access = private)
@@ -210,8 +210,12 @@ classdef HebiArm < handle
 
             % Call plugins (FK, Jacobians, End-Effector XYZ, etc.)
             this.state = newState;
-            for i=1:length(this.plugins)
-                this.plugins{i}.update(this);
+            pluginFields = fieldnames(this.plugins);
+            for i=1:length(pluginFields)
+                plugin = this.plugins.(pluginFields{i});
+                if plugin.enabled % Optional: check if the plugin is enabled
+                    plugin.update(this);
+                end
             end 
 
             % Ignore efforts that aren't used

--- a/include/hebi/HebiArm.m
+++ b/include/hebi/HebiArm.m
@@ -235,6 +235,22 @@ classdef HebiArm < handle
             % Send state to module
             this.group.send(this.cmd, varargin{:});
         end
+
+        function plugin = getPluginByType(this, type)
+            % getPluginByType Retrieves a plugin by its class type
+            %
+            % Example:
+            %   plugin = arm.getPluginByType('HebiArmPlugins.ImpedanceController');
+            
+            pluginFields = fieldnames(this.plugins);
+            for i = 1:length(pluginFields)
+                plugin = this.plugins.(pluginFields{i});
+                if isa(plugin, type)
+                    return;
+                end
+            end
+            error('Plugin of type "%s" not found.', type);
+        end
         
     end
     

--- a/include/hebi/HebiArmPlugin.m
+++ b/include/hebi/HebiArmPlugin.m
@@ -100,11 +100,11 @@ classdef HebiArmPlugin < handle
             % See also HebiArm, HebiUtils.loadRobotConfig
             
             pluginNames = fields(pluginMap);
-            numPlugins = numel(pluginNames);
-            out = cell(numPlugins, 1);
+            out = struct();
 
             for i = 1:numel(pluginNames)
-                out{i} = HebiArmPlugin.createFromConfig(pluginMap.(pluginNames{i}));
+                plugin = HebiArmPlugin.createFromConfig(pluginMap.(pluginNames{i}));
+                out.(plugin.name) = plugin; % Use plugin's name as the struct field name
             end
                 
         end


### PR DESCRIPTION
Plugins can now be accessed using arm.plugin.impedanceController where "impedanceController" is the "name" field of the plugin from the config file